### PR TITLE
change parameter in tileGenome

### DIFF
--- a/genomewide_plots_wgbs.txt.R
+++ b/genomewide_plots_wgbs.txt.R
@@ -7,7 +7,7 @@ library(data.table)
 library(RColorBrewer)
 
 # create genomic tiles of 10 kb
-tiles.pmd <- unlist(tileGenome(seqlengths=seqlengths(Hsapiens)[1:23], ntile=10000))
+tiles.pmd <- unlist(tileGenome(seqlengths=seqlengths(Hsapiens)[1:23], tilewidth=10000))
 
 # get the WGBS data (GRanges object, with CpG positions as rows, and
 # colnames PDxxxx.T = total reads, PDxxxx.M = methylated reads)


### PR DESCRIPTION
According to comment and description in corresponding article, there probably was a typo in the code: the parameter to use to create 10kb wide tiles is `tilewidth` instead of `ntile` (`ntile=10000` creates 10000 tiles).